### PR TITLE
compat: Allow Aqua 0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,8 @@ version = "0.3.2"
 [deps]
 
 [compat]
-Aqua = "0.6"
+Aqua = "0.6, 0.8"
+Test = "1"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
Aqua 0.6.x's type-piracy/ambiguity detection produces false positives under JuliaLang/julia#61915 (the TypeEq refactor): Type{T} is now a TypeEq kind, so the package's own inner constructors are mis-flagged as piracy. Aqua 0.8.15 fixes this. Allow Aqua 0.8 and add the [compat]/API adjustments required by Aqua 0.8 so the test suite passes on recent Julia.

This change was made with the assistance of generative AI (Claude Code).